### PR TITLE
feat: Implement MCP-HUB for Smithery server management

### DIFF
--- a/mcp-client-for-ollama/mcp_client_for_ollama/config/manager.py
+++ b/mcp-client-for-ollama/mcp_client_for_ollama/config/manager.py
@@ -254,4 +254,28 @@ class ConfigManager:
             if "enabled" in config_data["hilSettings"]:
                 validated["hilSettings"]["enabled"] = bool(config_data["hilSettings"]["enabled"])
 
+        if "installed_servers" in config_data and isinstance(config_data["installed_servers"], list):
+            validated["installed_servers"] = config_data["installed_servers"]
+
         return validated
+
+    def get_installed_servers(self, config_name: Optional[str] = None) -> list:
+        """Get the list of installed servers."""
+        config_data = self.load_configuration(config_name)
+        return config_data.get("installed_servers", [])
+
+    def add_installed_server(self, server_data: Dict[str, Any], config_name: Optional[str] = None):
+        """Add a server to the list of installed servers."""
+        config_data = self.load_configuration(config_name)
+        installed_servers = config_data.get("installed_servers", [])
+        installed_servers.append(server_data)
+        config_data["installed_servers"] = installed_servers
+        self.save_configuration(config_data, config_name)
+
+    def remove_installed_server(self, server_name: str, config_name: Optional[str] = None):
+        """Remove a server from the list of installed servers."""
+        config_data = self.load_configuration(config_name)
+        installed_servers = config_data.get("installed_servers", [])
+        updated_servers = [s for s in installed_servers if s.get("qualifiedName") != server_name]
+        config_data["installed_servers"] = updated_servers
+        self.save_configuration(config_data, config_name)

--- a/mcp-client-for-ollama/mcp_client_for_ollama/mcphub/mcphub_manager.py
+++ b/mcp-client-for-ollama/mcp_client_for_ollama/mcphub/mcphub_manager.py
@@ -1,0 +1,160 @@
+import asyncio
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
+from prompt_toolkit import PromptSession
+
+from .smithery_client import SmitheryClient
+from ..config.manager import ConfigManager
+
+class MCPHubManager:
+    """Manages the MCP-HUB TUI."""
+
+    def __init__(self, console: Console, smithery_client: SmitheryClient, config_manager: ConfigManager, client):
+        self.console = console
+        self.smithery_client = smithery_client
+        self.config_manager = config_manager
+        self.client = client
+        self.prompt_session = PromptSession()
+
+    async def run(self):
+        """Runs the main loop of the MCP-HUB."""
+        self.console.print(Panel(Text("Welcome to the MCP-HUB!", justify="center"), border_style="blue"))
+        while True:
+            self.print_menu()
+            try:
+                choice = await self.prompt_session.prompt_async("Enter your choice: ")
+                if choice == "1":
+                    await self.search_servers()
+                elif choice == "2":
+                    await self.install_server()
+                elif choice == "3":
+                    await self.uninstall_server()
+                elif choice == "4":
+                    await self.configure_api_key()
+                elif choice in ["5", "q", "quit"]:
+                    break
+                else:
+                    self.console.print("[red]Invalid choice. Please try again.[/red]")
+            except (KeyboardInterrupt, EOFError):
+                break
+
+    def print_menu(self):
+        """Prints the MCP-HUB menu."""
+        menu_text = """
+[bold]MCP-HUB Menu[/bold]
+1. Search for servers
+2. Install a server
+3. Uninstall a server
+4. Configure Smithery API Key
+5. Back to main menu (q, quit)
+"""
+        self.console.print(Panel(Text.from_markup(menu_text), title="MCP-HUB", border_style="blue"))
+
+    async def search_servers(self):
+        """Handles the server search workflow."""
+        try:
+            query = await self.prompt_session.prompt_async("Enter search query (or leave blank to list all): ")
+            with self.console.status("Searching..."):
+                results = await self.smithery_client.search_servers(query)
+
+            servers = results.get("servers", [])
+            if not servers:
+                self.console.print("[yellow]No servers found.[/yellow]")
+                return
+
+            from rich.table import Table
+            table = Table(title="Search Results")
+            table.add_column("Name", style="cyan")
+            table.add_column("Description")
+            table.add_column("Use Count", style="magenta")
+            table.add_column("Tools", style="green")
+
+            # Fetch details in parallel
+            tasks = [self.smithery_client.get_server(s["qualifiedName"]) for s in servers]
+            detailed_servers = await asyncio.gather(*tasks, return_exceptions=True)
+
+            for server in detailed_servers:
+                if isinstance(server, Exception):
+                    # Handle cases where a server detail fetch might fail
+                    continue
+                tool_count = len(server.get("tools", []))
+                table.add_row(
+                    server.get('qualifiedName'),
+                    server.get('description'),
+                    str(server.get('useCount')),
+                    str(tool_count)
+                )
+
+            self.console.print(table)
+
+        except Exception as e:
+            self.console.print(f"[red]Error searching for servers: {e}[/red]")
+
+    async def install_server(self):
+        """Handles the server installation workflow."""
+        try:
+            server_name = await self.prompt_session.prompt_async("Enter the name of the server to install: ")
+            with self.console.status(f"Getting details for {server_name}..."):
+                server_details = await self.smithery_client.get_server(server_name)
+
+            self.console.print(Panel(f"[bold]Name:[/bold] {server_details.get('displayName')}\n"
+                                   f"[bold]Description:[/bold] {server_details.get('description')}"))
+
+            # Handle configuration
+            config = {}
+            if "connections" in server_details and server_details["connections"]:
+                config_schema = server_details["connections"][0].get("configSchema")
+                if config_schema and "properties" in config_schema:
+                    for key, prop in config_schema["properties"].items():
+                        prompt = prop.get("description", f"Enter value for {key}")
+                        value = await self.prompt_session.prompt_async(f"{prompt}: ")
+                        config[key] = value
+
+            server_details["config"] = config
+
+            # Save the server to the configuration
+            self.config_manager.add_installed_server(server_details)
+            self.console.print(f"[green]Server '{server_name}' installed successfully.[/green]")
+
+            # Reload servers
+            await self.client.reload_servers()
+
+        except Exception as e:
+            self.console.print(f"[red]Error installing server: {e}[/red]")
+
+    async def uninstall_server(self):
+        """Handles the server uninstallation workflow."""
+        try:
+            installed_servers = self.config_manager.get_installed_servers()
+            if not installed_servers:
+                self.console.print("[yellow]No servers installed.[/yellow]")
+                return
+
+            from rich.table import Table
+            table = Table(title="Installed Servers")
+            table.add_column("Name", style="cyan")
+            table.add_column("Description")
+
+            for server in installed_servers:
+                table.add_row(server.get('qualifiedName'), server.get('description'))
+
+            self.console.print(table)
+
+            server_name = await self.prompt_session.prompt_async("Enter the name of the server to uninstall: ")
+
+            self.config_manager.remove_installed_server(server_name)
+            self.console.print(f"[green]Server '{server_name}' uninstalled successfully.[/green]")
+
+        except Exception as e:
+            self.console.print(f"[red]Error uninstalling server: {e}[/red]")
+
+    async def configure_api_key(self):
+        """Handles the API key configuration workflow."""
+        self.console.print("[green]Configuring Smithery API Key...[/green]")
+        try:
+            api_key = await self.prompt_session.prompt_async("Enter your Smithery API Key: ", is_password=True)
+            self.smithery_client.set_api_key(api_key)
+            self.console.print("[green]API Key saved successfully.[/green]")
+        except (KeyboardInterrupt, EOFError):
+            self.console.print("\n[yellow]API Key configuration cancelled.[/yellow]")

--- a/mcp-client-for-ollama/mcp_client_for_ollama/mcphub/smithery_client.py
+++ b/mcp-client-for-ollama/mcp_client_for_ollama/mcphub/smithery_client.py
@@ -1,0 +1,44 @@
+import httpx
+from ..config.manager import ConfigManager
+
+class SmitheryClient:
+    """A client for the Smithery Registry API."""
+
+    def __init__(self, config_manager: ConfigManager):
+        self.config_manager = config_manager
+        self.api_key = self.get_api_key()
+        self.base_url = "https://registry.smithery.ai"
+
+    def get_api_key(self) -> str | None:
+        """Retrieves the Smithery API key from the configuration."""
+        return self.config_manager.get_config().get("smithery_api_key")
+
+    def set_api_key(self, api_key: str):
+        """Saves the Smithery API key to the configuration."""
+        config_data = self.config_manager.get_config()
+        config_data["smithery_api_key"] = api_key
+        self.config_manager.save_configuration(config_data)
+        self.api_key = api_key
+
+    async def search_servers(self, query: str = "", page: int = 1, page_size: int = 10):
+        """Searches for servers on the Smithery Registry."""
+        if not self.api_key:
+            raise ValueError("Smithery API key is not set.")
+
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        params = {"q": query, "page": page, "pageSize": page_size}
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"{self.base_url}/servers", headers=headers, params=params)
+            response.raise_for_status()
+            return response.json()
+
+    async def get_server(self, server_id: str):
+        """Gets the details of a single server."""
+        if not self.api_key:
+            raise ValueError("Smithery API key is not set.")
+
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"{self.base_url}/servers/{server_id}", headers=headers)
+            response.raise_for_status()
+            return response.json()

--- a/mcp-client-for-ollama/pyproject.toml
+++ b/mcp-client-for-ollama/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "prompt-toolkit~=3.0.51",
     "rich~=14.1.0",
     "typer~=0.16.0",
+    "httpx~=0.27.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This commit introduces the MCP-HUB, a new feature for managing Model Context Protocol (MCP) servers from the Smithery.ai registry.

The MCP-HUB provides a TUI menu with the following functionalities:
- Search for MCP servers on the Smithery registry.
- Install and uninstall MCP servers.
- Configure the Smithery API key.

The implementation includes:
- A new `mcphub` module with a `SmitheryClient` for API interactions and an `MCPHubManager` for the TUI.
- Integration of the MCP-HUB into the main application's command loop.
- Extension of the `ConfigManager` to store information about installed servers.
- Update of the `ServerConnector` to load and connect to installed servers.
- Use of `asyncio.gather` for parallel fetching of server details.